### PR TITLE
[codex-demo] Improve greeter function and add tests

### DIFF
--- a/src/greeter.ts
+++ b/src/greeter.ts
@@ -1,7 +1,5 @@
-export function greet(name: string | null): string {
-  if (name === null || name === undefined || name === "") {
-    return "Hello, Guest";
-  } else {
-    return "Hello, " + name;
-  }
+export function greet(name?: string | null): string {
+  const trimmedName = name?.trim();
+  const finalName = trimmedName ? trimmedName : "Guest";
+  return `Hello, ${finalName}`;
 }

--- a/tests/greeter.test.ts
+++ b/tests/greeter.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { greet } from '../src/greeter';
+
+describe('greet', () => {
+  it('greets the provided name', () => {
+    expect(greet('Alice')).toBe('Hello, Alice');
+  });
+
+  it('defaults to Guest when name is null, undefined, or blank', () => {
+    expect(greet(null)).toBe('Hello, Guest');
+    expect(greet(undefined)).toBe('Hello, Guest');
+    expect(greet('')).toBe('Hello, Guest');
+    expect(greet('   ')).toBe('Hello, Guest');
+  });
+
+  it('trims the provided name', () => {
+    expect(greet('  Bob  ')).toBe('Hello, Bob');
+  });
+});


### PR DESCRIPTION
## Summary
- Handle undefined, null, and blank names in `greet` by trimming and defaulting to "Guest"
- Add unit tests for the greeter behavior and remove stray empty test file

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a configuration file)*
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6896cf789acc832096b99b0df4e86f49